### PR TITLE
コントローラーの下部に不要文字記載があった

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,4 +52,3 @@ class ItemsController < ApplicationController
     redirect_to action: :index unless user_signed_in? && (current_user.id == @item.user.id)
   end
 end
-destroy


### PR DESCRIPTION
#WHAT
不要文字が挿入してあった為

#WHY
エラーとなってしまう為、削除